### PR TITLE
minimal EssentialsDiscord support

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -9,6 +9,7 @@ repositories {
     maven("https://nexus.scarsz.me/content/groups/public/") // DiscordSRV
     maven("https://m2.dv8tion.net/releases") // JDA - Required by DiscordSRV
     maven("https://repo.unnamed.team/repository/unnamed-public/") // creative
+    maven("https://repo.essentialsx.net/releases/") // EssentialsDiscord
 }
 
 dependencies {
@@ -24,6 +25,7 @@ dependencies {
     compileOnly("me.clip:placeholderapi:2.10.10")
     compileOnly(files("../lib/TownyChat-0.91.jar", "../lib/EzChat-2.5.0-with-dependencies.jar"))
     compileOnly("com.discordsrv:discordsrv:1.26.0")
+    compileOnly("net.essentialsx:EssentialsXDiscord:2.19.7")
 
     // Testing
     testImplementation(spigot)
@@ -39,7 +41,7 @@ bukkit {
     apiVersion = "1.13"
     description = "Unnamed Team's Emojis Plugin"
     author = "Unnamed Team"
-    softDepend = listOf("PlaceholderAPI", "EzChat", "TownyChat", "DiscordSRV")
+    softDepend = listOf("PlaceholderAPI", "EzChat", "TownyChat", "DiscordSRV", "EssentialsDiscord")
     commands {
         create("emojis") {
             description = "Main command for the unemojis plugin"

--- a/plugin/src/main/java/team/unnamed/emojis/EmojisPlugin.java
+++ b/plugin/src/main/java/team/unnamed/emojis/EmojisPlugin.java
@@ -18,6 +18,7 @@ import team.unnamed.emojis.format.DefaultEmojiComponentProvider;
 import team.unnamed.emojis.hook.PluginHook;
 import team.unnamed.emojis.hook.PluginHookManager;
 import team.unnamed.emojis.hook.discordsrv.DiscordSRVHook;
+import team.unnamed.emojis.hook.essentialsdiscord.EssentialsDiscordHook;
 import team.unnamed.emojis.hook.ezchat.EzChatHook;
 import team.unnamed.emojis.hook.papi.PlaceholderApiHook;
 import team.unnamed.emojis.hook.townychat.TownyChatHook;
@@ -160,6 +161,7 @@ public class EmojisPlugin extends JavaPlugin {
                 .registerHook(new TownyChatHook(this, registry))
                 .registerHook(new PlaceholderApiHook(this, registry))
                 .registerHook(new DiscordSRVHook(registry))
+                .registerHook(new EssentialsDiscordHook(this, registry))
                 .hook();
 
         if (hooks.stream().noneMatch(hook -> hook instanceof PluginHook.Chat)) {

--- a/plugin/src/main/java/team/unnamed/emojis/hook/essentialsdiscord/EssentialsDiscordHook.java
+++ b/plugin/src/main/java/team/unnamed/emojis/hook/essentialsdiscord/EssentialsDiscordHook.java
@@ -1,0 +1,66 @@
+package team.unnamed.emojis.hook.essentialsdiscord;
+
+import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+import team.unnamed.emojis.Emoji;
+import team.unnamed.emojis.EmojiRegistry;
+import team.unnamed.emojis.hook.PluginHook;
+
+
+public class EssentialsDiscordHook
+        implements PluginHook, Listener {
+
+    private final Plugin plugin;
+    private final EmojiRegistry registry;
+
+    public EssentialsDiscordHook(Plugin plugin, EmojiRegistry registry) {
+        this.plugin = plugin;
+        this.registry = registry;
+    }
+
+    @Override
+    public String getPluginName() {
+        return "EssentialsDiscord";
+    }
+
+    @Override
+    public void hook(Plugin hook) {
+        Bukkit.getPluginManager().registerEvents(
+            new EssentialsDiscordListener(),
+            plugin);
+        plugin.getLogger().info("Successfully hooked with EssentialsDiscord!");
+    }
+
+    private class EssentialsDiscordListener implements Listener {
+
+        @EventHandler
+        public void onMessagePreProcess(DiscordChatMessageEvent event) {
+
+            String input = event.getMessage();
+            StringBuilder output = new StringBuilder();
+
+            for (int i = 0; i < input.length(); i++) {
+                char c = input.charAt(i);
+                Emoji emoji = registry.getByChar(c);
+
+                if (emoji == null) {
+                    // let it be
+                    output.append(c);
+                } else {
+                     // emoji found, replace by its name
+                    output.append(':')
+                              .append(emoji.name())
+                              .append(':');
+                }
+            }
+
+            event.setMessage(output.toString());
+    }
+
+}
+
+}


### PR DESCRIPTION
Adds minimal support for EssentialsDiscord (an alternative to DiscordSRV).

Emojis sent in Minecraft chat are replaced by their name in Discord.