### PR TITLE
increase 32 character emoji name to 48, because of some emojis. 

### DIFF
--- a/plugin/src/main/java/team/unnamed/emojis/format/EmojiFormat.java
+++ b/plugin/src/main/java/team/unnamed/emojis/format/EmojiFormat.java
@@ -14,11 +14,11 @@ public final class EmojiFormat {
     public static final char USAGE_START = ':';
     public static final char USAGE_END = ':';
 
-    public static final @RegExp String NAME_PATTERN_STR = "[a-z0-9_]{1,32}";
+    public static final @RegExp String NAME_PATTERN_STR = "[a-z0-9_]{1,48}";
     public static final @RegExp String PERMISSION_PATTERN_STR = "[A-Za-z0-9_.]*";
 
     // The exact same that EMOJI_NAME_PATTERN_STRING but accepting uppercase characters
-    public static final @RegExp String USAGE_PATTERN_STR = USAGE_START + "([A-Za-z0-9_]{1,32})" + USAGE_END;
+    public static final @RegExp String USAGE_PATTERN_STR = USAGE_START + "([A-Za-z0-9_]{1,48})" + USAGE_END;
 
     public static final Pattern PERMISSION_PATTERN = Pattern.compile(PERMISSION_PATTERN_STR);
     public static final Pattern NAME_PATTERN = Pattern.compile(NAME_PATTERN_STR);


### PR DESCRIPTION
face_with_open_eyes_and_hand_over_mouth (🫢) is 39 characters 
and
hand_with_index_finger_and_thumb_crossed (🫰) is 40 characters.